### PR TITLE
Adicionando tipo e status do evento

### DIFF
--- a/tracking_test.go
+++ b/tracking_test.go
@@ -34,7 +34,7 @@ func TestTracking(t *testing.T) {
 		t.Errorf("Error while getting Tracking: %v", err)
 	}
 
-	responseInterface := []map[string]interface{}{}
+	var responseInterface []map[string]interface{}
 	err = json.Unmarshal(response, &responseInterface)
 	if err != nil {
 		t.Errorf("Cannot convert to json: %v", err)
@@ -42,9 +42,11 @@ func TestTracking(t *testing.T) {
 
 	assert.Equal(t, len(responseInterface), 1)
 	assert.Equal(t, responseInterface[0]["number"], codeNumber)
-	assert.Contains(t, responseInterface[0], "last_date")
 	assert.Contains(t, responseInterface[0], "category")
+	assert.Contains(t, responseInterface[0], "last_date")
+	assert.Contains(t, responseInterface[0], "last_type")
 	assert.Contains(t, responseInterface[0], "last_status")
+	assert.Contains(t, responseInterface[0], "last_description")
 	assert.Contains(t, responseInterface[0], "last_detail")
 	assert.Contains(t, responseInterface[0], "last_origin")
 	assert.Contains(t, responseInterface[0], "last_destination")
@@ -57,7 +59,7 @@ func TestTrackingNotExist(t *testing.T) {
 		t.Errorf("Error while getting Tracking: %v", err)
 	}
 
-	responseInterface := []map[string]interface{}{}
+	var responseInterface []map[string]interface{}
 	err = json.Unmarshal(response, &responseInterface)
 	if err != nil {
 		t.Errorf("Cannot convert to json: %v", err)
@@ -73,7 +75,7 @@ func TestTrackingMultipleObjects(t *testing.T) {
 		t.Errorf("Error while getting Tracking: %v", err)
 	}
 
-	responseInterface := []map[string]interface{}{}
+	var responseInterface []map[string]interface{}
 	err = json.Unmarshal(response, &responseInterface)
 	if err != nil {
 		t.Errorf("Cannot convert to json: %v", err)


### PR DESCRIPTION
## Qual o problema inicial?
Só recebemos a descrição do evento de entrega como status. Isso dificulta para verificar se uma entrega chegou no seu status final, visto que existem 348 possíveis eventos de entrega e seria necessário comparar as descrições que são extensas.

Uma forma mais simples de fazer isso é comparar usando o tipo e status de evento, seguindo os eventos informados no manual de rastreamento dos Correios:
https://www.correios.com.br/enviar-e-receber/precisa-de-ajuda/manual_rastreamentoobjetosws.pdf
<details><summary>Print do manual</summary>

![image](https://user-images.githubusercontent.com/23525788/97472967-2e88c180-1929-11eb-81d5-6c9fdbaff6c9.png)
</details>

## O que esse PR faz?
Adiciona o tipo e o status dos eventos de entrega.

## Como testar?
- Verifique se é exibido os campos `last_type`, `last_status` e `last_description` no objeto e se existe os campos `type`, `status` e `description` em cada um dos objetos da lista `history`.
```go
package main

import (
    "fmt"
    "github.com/AlisonOSouza/gocorreios"
)

func main() {
    res, err := gocorreios.Tracking([]string{"OK816158697BR"})
    if err != nil {
        fmt.Println("[ERRO]:", err.Error())
        return
    }

    fmt.Println(string(res))
}
```

